### PR TITLE
Rest Cache Cleanup

### DIFF
--- a/inc/class-wrc-caching.php
+++ b/inc/class-wrc-caching.php
@@ -286,17 +286,21 @@ class WRC_Caching {
 		/**
 		 * TODO: get guaranteed UTC time here, Seth and Justin had to do the same
 		 */
-
-		if ( strtotime( $data['rest_expires'] ) < time() && 1 != $data['rest_to_update'] ) {
-
-			// instead of updating rest_expires, update rest_timeout_length
-			$data['rest_args']      = maybe_serialize( $args );
-			$data['rest_to_update'] = 1;
-
-			global $wpdb;
+		global $wpdb;
+		$doUpdate = false;
+		switch(true){
+			case 1 == $data['rest_to_update']:
+				$doUpdate = true;
+				break;
+			case strtotime( $data['rest_expires'] ) < time():
+				$doUpdate = true;
+				$data['rest_args']      = maybe_serialize( $args );
+				$data['rest_to_update'] = 1;
+				break;
+		}
+		if($doUpdate){
+			$data['rest_last_requested'] = date('Y-m-d');
 			$wpdb->replace( REST_CACHE_TABLE, $data );
 		}
-
 	}
-
 }

--- a/inc/class-wrc-cron.php
+++ b/inc/class-wrc-cron.php
@@ -73,7 +73,7 @@ class WRC_Cron {
 				$cronsScheduled = true;
 			}
 			if( ! wp_next_scheduled( 'wp_rest_cache_expired_cron' ) ) {
-				wp_schedule_event( time(), '5_minutes', 'wp_rest_cache_expired_cron' );
+				wp_schedule_event( time(), 'hourly', 'wp_rest_cache_expired_cron' );
 				$cronsScheduled = true;
 			}
 			if( $cronsScheduled ) {

--- a/inc/class-wrc-cron.php
+++ b/inc/class-wrc-cron.php
@@ -112,6 +112,16 @@ LIMIT ' . $limit;
 			$cache_cleared  = $cache_failed = $cache_attempted = 0;
 			self::maybe_log( 'log', 'Found ' . $cache_to_clear . ' records we need to update cache for.' );
 			foreach ( $results as $row ) {
+
+				// Call has not been requested in a month, get rid of it.
+				if(strtotime($row['rest_last_requested']) < strtotime('-30 days')){
+					$wpdb::delete( 'wp_rest_cache', [
+						'rest_md5'       => $row['rest_md5'],
+						'rest_to_update' => 1
+					] );
+					continue;
+				}
+
 				// run maybe_unserialize on rest_args and check to see if the update arg is set and set to false if it is
 				$args = maybe_unserialize( $row['rest_args'] );
 				$url  = $row['rest_domain'] . $row['rest_path'];

--- a/inc/class-wrc-cron.php
+++ b/inc/class-wrc-cron.php
@@ -209,7 +209,7 @@ LIMIT ' . $limit;
 			// executed successfully
 		}else{
 			if ( function_exists( 'newrelic_notice_error' ) ) {
-				newrelic_notice_error( 'CRON FAIL: Unable to perform cleanup on un-requested old API cache.' );
+				newrelic_notice_error( 'CRON FAIL: Unable to perform cleanup on un-requested old API cache. Limit ' . $limit . ', Expired ' . $expiredBefore );
 			}
 		}
 		return;

--- a/inc/class-wrc-cron.php
+++ b/inc/class-wrc-cron.php
@@ -239,7 +239,7 @@ LIMIT ' . $limit;
 			'rest_query_args'     => $query,
 			'rest_response'       => maybe_serialize( $response ),
 			'rest_expires'        => $expiration_date,
-			'rest_last_requested' => date( 'Y-m-d', time() ),
+			//'rest_last_requested' => date( 'Y-m-d', time() ),
 			// current UTC time
 			'rest_tag'            => $tag,
 			'rest_to_update'      => $update,

--- a/inc/class-wrc-cron.php
+++ b/inc/class-wrc-cron.php
@@ -21,6 +21,7 @@ class WRC_Cron {
 		// set up any Cron needs, this should be able to run independently of the front-end processes
 		add_action( 'wp', array( get_called_class(), 'schedule_cron' ) );
 		add_action( 'wp_rest_cache_cron', array( get_called_class(), 'check_cache_for_updates' ) );
+		add_action( 'wp_rest_cache_expired_cron', array( get_called_class(), 'check_expired_cache' ) );
 		add_filter( 'cron_schedules', array( get_called_class(), 'add_schedule_interval' ) );
 	}
 
@@ -65,10 +66,19 @@ class WRC_Cron {
 		 */
 		if (
 			( ! $is_multisite || ( $is_multisite && $primary_blog->id === $current_blog ) )
-			&& ! wp_next_scheduled( 'wp_rest_cache_cron' )
 		) {
-			wp_schedule_event( time(), '5_minutes', 'wp_rest_cache_cron' );
-			do_action( 'wrc_after_schedule_cron', $primary_blog, $current_blog );
+			$cronsScheduled = false;
+			if( ! wp_next_scheduled( 'wp_rest_cache_cron' ) ) {
+				wp_schedule_event( time(), '5_minutes', 'wp_rest_cache_cron' );
+				$cronsScheduled = true;
+			}
+			if( ! wp_next_scheduled( 'wp_rest_cache_expired_cron' ) ) {
+				wp_schedule_event( time(), '5_minutes', 'wp_rest_cache_expired_cron' );
+				$cronsScheduled = true;
+			}
+			if( $cronsScheduled ) {
+				do_action( 'wrc_after_schedule_cron', $primary_blog, $current_blog );
+			}
 		}
 	}
 
@@ -170,6 +180,40 @@ LIMIT ' . $limit;
 		self::maybe_log( 'log', get_called_class() . ' has been completed.' );
 
 		return;
+	}
+
+	/**
+	 * Retrieve rows that have not been requested after their expiration
+	 * Limiting to records older than 1 year
+	 */
+	static function check_expired_cache(){
+
+		global $wpdb;
+		$limit = 2000;
+		if ( class_exists( 'WRC_Logger' ) ) {
+			self::$logger = new WRC_Logger( get_called_class() );
+			$cron_limit   = get_option( WRC_Logger::SETTING_FLAG . '_limit', '2000' );
+			if ( is_numeric( $cron_limit ) ) {
+				$limit = $cron_limit;
+			}
+		}
+
+		$expiredBefore = date('Y-m-d', strtotime('-1 year'));
+
+		$query   = '
+DELETE FROM ' . REST_CACHE_TABLE . ' 
+WHERE  rest_expires < "' . $expiredBefore . '" AND rest_to_update=0
+LIMIT ' . $limit;
+
+		if($wpdb::query($query)){
+			// executed successfully
+		}else{
+			if ( function_exists( 'newrelic_notice_error' ) ) {
+				newrelic_notice_error( 'CRON FAIL: Unable to perform cleanup on un-requested old API cache.' );
+			}
+		}
+		return;
+
 	}
 
 	/**


### PR DESCRIPTION
As of right now we have a `rest_last_requested`, originally the thought was that it records when the call was last made with the same parameters.

This is true and false,
`rest_last_requested` = Last time cron ran and pulled a fresh copy of the endpoint, **not when the request from WP was last made and was intercepted**
https://github.com/fansided/wordpress-rest-cache/blob/master/inc/class-wrc-cron.php#L232

I found the admin page that looks like the interface for deleting old posts, which the CRON is not setup to do at all.
https://fansidedblogs.com/wp-admin/network/settings.php?page=wp_rest_cache

**Runs:** https://github.com/fansided/wordpress-rest-cache/blob/master/inc/class-wrc-db.php#L92-L116

So unless this is manually managed, we can do something programmatically or allow our table to just grow and grow until it becomes unusable.